### PR TITLE
Set key param instead of act.

### DIFF
--- a/TL_ROOT/system/modules/associategroups/dca/tl_user.php
+++ b/TL_ROOT/system/modules/associategroups/dca/tl_user.php
@@ -5,7 +5,7 @@ $GLOBALS['TL_DCA']['tl_user']['config']['onsubmit_callback'][] = array('Associat
 
 $GLOBALS['TL_DCA']['tl_user']['list']['global_operations']['sync_associate_groups'] = array(
 	'label'				=> &$GLOBALS['TL_LANG']['tl_user']['sync_associate_groups'],
-	'href'				=> 'act=sync_tl_user_to_group',
+	'href'				=> 'key=sync_tl_user_to_group',
 	'class'				=> 'sync_associate_groups header_sync_all',
 	'attributes'		=> 'onclick="Backend.getScrollOffset();"',
 );


### PR DESCRIPTION
The key request param has to be used to call the custom module.